### PR TITLE
Cherry-pick - GCB Queue TTL, Chef build size limit increase

### DIFF
--- a/integrations/cloudbuild/README.md
+++ b/integrations/cloudbuild/README.md
@@ -6,7 +6,8 @@ Follow https://cloud.google.com/sdk/docs/install.
 
 #### Local execution
 
-In order to test locally, comment out the `machineType` entry in the build yaml.
+In order to test locally, comment out the `machineType` and `queueTtl` entry in
+the build yaml.
 
 ```
 # Once only setup:

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -31,7 +31,8 @@ steps:
 logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
-timeout: 14400s
+timeout: 21600s
+queueTtl: 21600s
 
 artifacts:
     objects:

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -54,4 +54,4 @@ artifacts:
 # slow.
 options:
     machineType: "E2_HIGHCPU_32"
-    diskSizeGb: 200
+    diskSizeGb: 500

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -44,6 +44,7 @@ logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
 timeout: 14400s
+queueTtl: 21600s
 
 artifacts:
     objects:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -100,6 +100,7 @@ logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
 timeout: 9000s
+queueTtl: 21600s
 
 artifacts:
     objects:


### PR DESCRIPTION
#### Problem
* Fix chef build size limitation
* Set build q time to 6 hr

#### Change overview
* 2022-07-14   GCB Queue TTL (project-chip/connectedhomeip#20748)
* 2022-07-21  Cherry pick - Chef noip fix, Chef automated_test_stamp to Chef CD builds (#4)

#### Testing
* Integration changes N/A