### PR TITLE
Fix BLE subcriptions on EFR32

### DIFF
--- a/src/platform/EFR32/gatt_db.c
+++ b/src/platform/EFR32/gatt_db.c
@@ -55,9 +55,9 @@ GATT_DATA(const sli_bt_gattdb_value_t gattdb_attribute_field_26) = { .len  = 16,
                                                                      } };
 GATT_DATA(sli_bt_gattdb_attribute_chrvalue_t
               gattdb_attribute_field_24)                         = { .properties = 0x3e,
-                                                                     .max_len    = 247,
-                                                                     .len        = 1,
-                                                                     .data       = {
+                                             .max_len    = 247,
+                                             .len        = 1,
+                                             .data       = {
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -79,9 +79,9 @@ GATT_DATA(sli_bt_gattdb_attribute_chrvalue_t
                                              } };
 GATT_DATA(sli_bt_gattdb_attribute_chrvalue_t
               gattdb_attribute_field_22)                         = { .properties = 0x0a,
-                                                                     .max_len    = 247,
-                                                                     .len        = 1,
-                                                                     .data       = {
+                                             .max_len    = 247,
+                                             .len        = 1,
+                                             .data       = {
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/src/platform/EFR32/gatt_db.c
+++ b/src/platform/EFR32/gatt_db.c
@@ -55,9 +55,9 @@ GATT_DATA(const sli_bt_gattdb_value_t gattdb_attribute_field_26) = { .len  = 16,
                                                                      } };
 GATT_DATA(sli_bt_gattdb_attribute_chrvalue_t
               gattdb_attribute_field_24)                         = { .properties = 0x3e,
-                                             .max_len    = 247,
-                                             .len        = 1,
-                                             .data       = {
+                                                                     .max_len    = 247,
+                                                                     .len        = 1,
+                                                                     .data       = {
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -79,9 +79,9 @@ GATT_DATA(sli_bt_gattdb_attribute_chrvalue_t
                                              } };
 GATT_DATA(sli_bt_gattdb_attribute_chrvalue_t
               gattdb_attribute_field_22)                         = { .properties = 0x0a,
-                                             .max_len    = 247,
-                                             .len        = 1,
-                                             .data       = {
+                                                                     .max_len    = 247,
+                                                                     .len        = 1,
+                                                                     .data       = {
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -352,7 +352,7 @@ GATT_DATA(const sli_bt_gattdb_attribute_t gattdb_attributes_map[]) = {
       .caps           = 0xffff,
       .state          = 0x00,
       .datatype       = 0x05,
-      .characteristic = { .properties = 0x3e, .char_uuid = 0x8001 } },
+      .characteristic = { .properties = 0x1e, .char_uuid = 0x8001 } },
     { .handle      = 0x19,
       .uuid        = 0x8001,
       .permissions = 0x807,
@@ -366,7 +366,7 @@ GATT_DATA(const sli_bt_gattdb_attribute_t gattdb_attributes_map[]) = {
       .caps        = 0xffff,
       .state       = 0x00,
       .datatype    = 0x03,
-      .configdata  = { .flags = 0x03, .clientconfig_index = 0x01 } },
+      .configdata  = { .flags = 0x01, .clientconfig_index = 0x01 } },
     { .handle      = 0x1b,
       .uuid        = 0x0000,
       .permissions = 0x801,


### PR DESCRIPTION
preface: At the time of TE9, notification was used for the BLE TX GATT characteristics.

Problem
A new case is seen when phones try to subscribe using indications and have a fallback to notification if that is not allowed by the device.

EFR32 code only handles notification exchanges on the TX characteristics but doesn't refuse a subscription with indications.

Change overview
Update the EFR32 GATT settings to disallow BLE subscriptions using indications.

Testing
Build efr32 Lighting-app
Commissioning and control done with google hub gen 2
Ken Leone from google reported the new issue and helped me validate the fix.